### PR TITLE
Make company and phone fields optional for lead creation

### DIFF
--- a/database/migrations/2025_07_24_171257_make_phone_nullable_in_leads_table.php
+++ b/database/migrations/2025_07_24_171257_make_phone_nullable_in_leads_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('leads', function (Blueprint $table) {
+            $table->string('phone')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('leads', function (Blueprint $table) {
+            $table->string('phone')->nullable(false)->change();
+        });
+    }
+};


### PR DESCRIPTION
- Created migration to make company field nullable in leads table
- Created migration to make phone field nullable in leads table
- Updated StoreLeadRequest validation to make company optional
- Updated API documentation to reflect company as optional field
- Updated Swagger documentation to remove company from required fields
- Regenerated Swagger docs

This allows API lead creation with only name and email as required fields, fixing Pipedream integration issues.